### PR TITLE
Fix a mistake introduced during porting to Python 3

### DIFF
--- a/src/OpenOPC.py
+++ b/src/OpenOPC.py
@@ -571,7 +571,7 @@ class client():
                   value = None
                   quality = 'Error'
                   timestamp = None
-                  if tag in include_error and not error_msgs:
+                  if include_error and not tag in error_msgs:
                      error_msgs[tag] = ''
 
                if single:


### PR DESCRIPTION
The line:

"if include_error and not error_msgs.has_key(tag):"

was converted into:

"if tag in include_error and not error_msgs:"