### PR TITLE
Fix iproperties due to failure of map() function, Fix OpenOPCService failure to start issues

### DIFF
--- a/src/OpenOPC.py
+++ b/src/OpenOPC.py
@@ -933,7 +933,7 @@ class client():
                count, property_id, descriptions, datatypes = self._opc.QueryAvailableProperties(tag)
 
                # Remove bogus negative property id (not sure why this sometimes happens)
-               tag_properties = map(None, property_id, descriptions)
+               tag_properties = list(map(lambda x, y: (x, y), property_id, descriptions))
                property_id = [p for p, d in tag_properties if p > 0]
                descriptions = [d for p, d in tag_properties if p > 0]
 
@@ -973,9 +973,9 @@ class client():
                   else:
                      tag_properties = [values]
                else:
-                  tag_properties = map(None, property_id, values)
+                  tag_properties = list(map(lambda x, y: (x, y), property_id, values))
             else:
-               tag_properties = map(None, property_id, descriptions, values)
+               tag_properties = list(map(lambda x, y, z: (x, y, z), property_id, descriptions, values))
                tag_properties.insert(0, (0, 'Item ID (virtual property)', tag))
 
             if include_name:    tag_properties.insert(0, (0, tag))

--- a/src/OpenOPCService.py
+++ b/src/OpenOPCService.py
@@ -34,8 +34,8 @@ Pyro4.config.SERVERTYPE='thread'
 #Pyro4.config.SERIALIZER='marshal'
 
 opc_class = OpenOPC.OPC_CLASS
-opc_gate_host = os.environ['OPC_GATE_HOST']
-opc_gate_port = int(os.environ['OPC_GATE_PORT'])
+opc_gate_host = "localhost"
+opc_gate_port = 7766
 
 def getvar(env_var):
     """Read system environment variable from registry"""
@@ -49,9 +49,9 @@ def getvar(env_var):
 # Get env vars directly from the Registry since a reboot is normally required
 # for the Local System account to inherit these.
 
-#if getvar('OPC_CLASS'):  opc_class = getvar('OPC_CLASS')
-#if getvar('OPC_GATE_HOST'):  opc_gate_host = getvar('OPC_GATE_HOST')
-#if getvar('OPC_GATE_PORT'):  opc_gate_port = int(getvar('OPC_GATE_PORT'))
+if getvar('OPC_CLASS'):  opc_class = getvar('OPC_CLASS')
+if getvar('OPC_GATE_HOST'):  opc_gate_host = getvar('OPC_GATE_HOST')
+if getvar('OPC_GATE_PORT'):  opc_gate_port = int(getvar('OPC_GATE_PORT'))
 
 @Pyro4.expose    # needed for version 4.55
 class opc(object):
@@ -159,3 +159,4 @@ if __name__ == '__main__':
             daemon.shutdown()
         else:
             win32serviceutil.HandleCommandLine(OpcService)
+            


### PR DESCRIPTION
OpenOPC.py
- modified map() functions in iproperties method.  original map(none, list1, list2) fails due to differences between python 2.# and 3.#. Error to the effect "none is not a callable function".  utilized lambda function to circumvent.

OpenOPCService.py
- service would "fail to start in a timely manner".  issue could be circumvented by running the service as the user or as admin account.  Main issue is use of "os.environ" suspect it requires elevated privileges. 

modified code to use the built in "getvar"
 